### PR TITLE
Added metadata in options for createFabric method

### DIFF
--- a/docs/Reference/Database/FabricManipulation.md
+++ b/docs/Reference/Database/FabricManipulation.md
@@ -191,10 +191,12 @@ Creates a new Fabric with the given `fabricName`.
 - **options**: `Object`
 
   - **dcList**: `string`
+  
     A comma separated list of data centers. It is a mandatory field, but if not specified (due to user error), it defaults
 to the local Edge Location.
 
   - **spotDc**: `string` (optional)
+
     The data center to be made as spot data center for this client. It has three different behaviour depending upon the value.
 
       `AUTOMATIC` -  The spot DC is chosen automatically if this key is not present in the `options` object.

--- a/docs/Reference/Database/FabricManipulation.md
+++ b/docs/Reference/Database/FabricManipulation.md
@@ -204,6 +204,7 @@ to the local Edge Location.
       `DC name` - If passed a valid DC name as the value, then that DC will be made the spot DC for this client.
 
 - **metadata**: `Object` (optional)
+
   An optional JSON object with user defined key-value pairs.    
 
 - **users**: `Array<string>` (optional)

--- a/docs/Reference/Database/FabricManipulation.md
+++ b/docs/Reference/Database/FabricManipulation.md
@@ -203,6 +203,9 @@ to the local Edge Location.
 
       `DC name` - If passed a valid DC name as the value, then that DC will be made the spot DC for this client.
 
+- **metadata**: `Object` (optional)
+  An optional JSON object with user defined key-value pairs.    
+
 - **users**: `Array<string>` (optional)
 
   An array of usernames

--- a/src/fabric.ts
+++ b/src/fabric.ts
@@ -89,6 +89,7 @@ export type ServiceOptions = {
 export interface CreateFabricOptions {
   dcList: string; //comma separated string, can also be ""
   spotDc?: string;
+  metadata?: object;
 }
 
 const FABRIC_NOT_FOUND = 1228;


### PR DESCRIPTION
## Description

This pr resolves this issue in https://macrometa.atlassian.net/browse/CLI-25 which we have added missing metadata in createFabric options.


- [x] Bug fix (non-breaking change which fixes an issue)
